### PR TITLE
Lkmm-ctrl-dep

### DIFF
--- a/doitlk-llvm-build.py
+++ b/doitlk-llvm-build.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+import os
+
+CMAKE_CONFIG_FLAGS = ["-DLLVM_ENABLE_PROJECTS=\"clang;clang-tools-extra;lldb\"",
+                      "-DLLVM_TARGETS_TO_BUILD=\"AArch64;ARM;X86\"",
+                      "-DLLVM_TARGET_ARCH=\"AArch64\"",
+                      "-DLLVM_DEFAULT_TARGET_TRIPLE=\"aarch64-unknown-linux-gnu\"",
+                      "-DCMAKE_BUILD_TYPE=\"DEBUG\"",
+                      "-DLLVM_ENABLE_ASSERTIONS=\"ON\"",
+                      "-DCMAKE_EXPORT_COMPILE_COMMANDS=\"ON\"",
+                      "-DLLVM_CCACHE_BUILD=\"ON\""
+                      ]
+
+
+def configure_llvm():
+    os.chdir("build")
+    CmdStr = "cmake -G Ninja " + " ".join(map(str, CMAKE_CONFIG_FLAGS)) + " ../llvm",
+    subprocess.run(CmdStr, shell=True, check=True)
+
+
+def build_llvm(target):
+    subprocess.run(["ninja", target], check=True)
+
+
+if __name__ == "__main__":
+    match sys.argv[1]:
+        case "config":
+            configure_llvm()
+        case "build":
+            build_llvm(sys.argv[2])

--- a/doitlk-llvm-build.sh
+++ b/doitlk-llvm-build.sh
@@ -4,7 +4,7 @@
 cd build
 
 cmake -G Ninja \
-  -DLLVM_ENABLE_PROJECTS="clang;lldb" \
+  -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb" \
   -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" \
   -DLLVM_TARGET_ARCH="AArch64" \
   -DLLVM_DEFAULT_TARGET_TRIPLE="aarch64-unknown-linux-gnu" \

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1412,6 +1412,11 @@ bool PotCtrlDepBeg::progressCtrlPaths(
   for (auto &s : *SuccessorsWOBackEdges)
     CtrlPaths.insert(s);
 
+  // Account for the case where the condition has a backedge, e.g. in a do-while
+  // loop.
+  if (HasBackEdges)
+    CtrlPaths.insert(BB);
+
   return false;
 }
 

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -2119,9 +2119,9 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
     DepKindStr = "Control dependency";
   }
 
-  errs() << "==========\n";
-  errs() << DepKindStr << " with ID " << ID
-         << " couldn't be verified. It might have been broken.\n";
+  errs() << "//===--------------------------Broken "
+            "Dependency---------------------------===//\n";
+  errs() << DepKindStr << " with ID: " << ID << "\n";
 
   errs() << "Dependency Beginning:\n";
   errs() << "source code path to beginning:\n\t" << Beg.getParsedPathTo()
@@ -2162,7 +2162,9 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
   }
 #undef DEBUG_TYPE
 
-  errs() << "==========\n\n";
+  errs() << "//"
+            "===---------------------------------------------------------------"
+            "-------===//\n\n";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -2276,8 +2276,12 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
   errs() << DepKindStr << " with ID: " << ID << "\n\n";
 
   errs() << "Dependency Beginning:\t" << Beg.getParsedDepHalfID() << "\n";
+  errs() << "\nPath to (via files) from annotation: "
+         << Beg.getParsedpathTOViaFiles() << "\n";
 
   errs() << "\nDependnecy Ending:\t" << End.getParsedDepHalfID() << "\n";
+  errs() << "\nPath to (via files) from annotation: "
+         << End.getParsedpathTOViaFiles() << "\n";
 
   if (auto *VADE = dyn_cast<VerAddrDepEnd>(&End))
     errs() << "\nFull dependency: " << (VADE->getParsedFullDep() ? "yes" : "no")

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -2121,18 +2121,18 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
 
   errs() << "//===--------------------------Broken "
             "Dependency---------------------------===//\n";
-  errs() << DepKindStr << " with ID: " << ID << "\n";
+  errs() << DepKindStr << " with ID: " << ID << "\n\n";
 
   errs() << "Dependency Beginning:\n";
   errs() << "source code path to beginning:\n\t" << Beg.getParsedPathTo()
          << "\n";
   if (auto *VCDB = dyn_cast<VerCtrlDepBeg>(&Beg)) {
-    errs() << "source code path to branch:\n\t" << VCDB->getParsedPathToBranch()
+    errs() << "Source code path to branch:\n\t" << VCDB->getParsedPathToBranch()
            << "\n";
   }
 
   errs() << "\nDependnecy Ending:\n";
-  errs() << "source code path to ending:\n\t" << End.getParsedPathTo() << "\n";
+  errs() << "Source code path to ending:\n\t" << End.getParsedPathTo() << "\n";
   if (auto *VADE = dyn_cast<VerAddrDepEnd>(&End))
     errs() << "Full dependency: " << (VADE->getParsedFullDep() ? "yes" : "no")
            << "\n";
@@ -2151,7 +2151,7 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
 
   LLVM_DEBUG(End.getInst()->print(dbgs()));
 
-  LLVM_DEBUG(dbgs() << "\noptimised IR function:\n\t"
+  LLVM_DEBUG(dbgs() << "\nOptimised IR function:\n\t"
                     << End.getInst()->getFunction()->getName() << "\n\n");
 
   if (PrintedModules.find(Beg.getInst()->getModule()) == PrintedModules.end()) {

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -33,6 +33,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
 #include <list>
 #include <queue>
 #include <string>
@@ -2121,7 +2122,6 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
   errs() << "==========\n";
   errs() << DepKindStr << " with ID " << ID
          << " couldn't be verified. It might have been broken.\n";
-  errs() << "==========\n\n";
 
   errs() << "Dependency Beginning:\n";
   errs() << "source code path to beginning:\n\t" << Beg.getParsedPathTo()
@@ -2137,30 +2137,32 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
     errs() << "Full dependency: " << (VADE->getParsedFullDep() ? "yes" : "no")
            << "\n";
 
-  errs() << "\nFirst access(es) in optimised IR\n\n";
+#define DEBUG_TYPE "lkmm-print-modules"
+  LLVM_DEBUG(dbgs() << "\nFirst access in optimised IR\n\n"
+                    << "inst:\n\t";);
 
-  errs() << "inst:\n\t";
-  Beg.getInst()->print(errs());
-  errs() << "\noptimised IR function:\n\t"
-         << Beg.getInst()->getFunction()->getName() << "\n";
+  LLVM_DEBUG(Beg.getInst()->print(dbgs()));
 
-  errs() << "\n";
+  LLVM_DEBUG(dbgs() << "\noptimised IR function:\n\t"
+                    << Beg.getInst()->getFunction()->getName() << "\n\n");
 
-  errs() << "\nSecond access(es) in optimised IR\n\n";
+  LLVM_DEBUG(dbgs() << "\nSecond access in optimised IR\n\n"
+                    << "inst:\n\t");
 
-  errs() << "inst:\n\t";
-  End.getInst()->print(errs());
-  errs() << "\noptimised IR function:\n\t"
-         << End.getInst()->getFunction()->getName() << "\n";
+  LLVM_DEBUG(End.getInst()->print(dbgs()));
 
-  errs() << "\n";
+  LLVM_DEBUG(dbgs() << "\noptimised IR function:\n\t"
+                    << End.getInst()->getFunction()->getName() << "\n\n");
 
   if (PrintedModules.find(Beg.getInst()->getModule()) == PrintedModules.end()) {
-    errs() << "Optimised IR module:\n";
-    Beg.getInst()->getModule()->print(errs(), nullptr);
+    LLVM_DEBUG(dbgs() << "Optimised IR module:\n");
+    LLVM_DEBUG(Beg.getInst()->getModule()->print(dbgs(), nullptr));
 
     PrintedModules.insert(Beg.getInst()->getModule());
   }
+#undef DEBUG_TYPE
+
+  errs() << "==========\n\n";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -57,12 +57,13 @@ constexpr StringRef AddrDepEndStr = "LKMMDep: address dep end";
 constexpr StringRef CtrlDepBegStr = "LKMMDep: ctrl dep begin";
 constexpr StringRef CtrlDepEndStr = "LKMMDep: ctrl dep end";
 
-// FIXME Is there a more elegant way of dealing with duplicate IDs (preferably
-// getting eliminating the problem all together)?
+// FIXME Is there a more elegant way of dealing with duplicate IDs
+// (preferably getting eliminating the problem all together)?
 
-// The IDReMap type alias represents the map of IDs to sets of alias IDs which
-// verification contexts use for remapping duplicate IDs. Duplicate IDs appear
-// when an annotated instruction is duplicated as part of optimizations.
+// The IDReMap type alias represents the map of IDs to sets of alias IDs
+// which verification contexts use for remapping duplicate IDs. Duplicate
+// IDs appear when an annotated instruction is duplicated as part of
+// optimizations.
 using IDReMap =
     std::unordered_map<std::string, std::unordered_set<std::string>>;
 
@@ -1127,12 +1128,12 @@ private:
   /// \param ID a reference to the ID which should be updated.
   void updateID(std::string &ID) {
     if (RemappedIDs->find(ID) == RemappedIDs->end()) {
-      RemappedIDs->emplace(ID, std::unordered_set<std::string>{ID + "-1"});
-      ID = ID + "-1";
+      RemappedIDs->emplace(ID, std::unordered_set<std::string>{ID + "-#1"});
+      ID = ID + "-#1";
     } else {
-      RemappedIDs->at(ID).insert(
-          ID + "-" + (std::to_string(RemappedIDs->at(ID).size() + 1)));
-      ID = ID + "-" + (std::to_string(RemappedIDs->at(ID).size() + 1));
+      auto S = RemappedIDs->at(ID).size();
+      RemappedIDs->at(ID).insert(ID + "-#" + std::to_string(S + 1));
+      ID = ID + "-#" + std::to_string(S + 1);
     }
   }
 
@@ -1963,10 +1964,10 @@ bool VerCtx::handleAddrDepID(std::string const &ID, Instruction *I,
       return true;
     }
 
-    // We only add the current annotation as a broken ending if the current BFS
-    // has seen the beginning ID. If we were to add unconditionally, we might
-    // add endings which aren't actually reachable by the corresponding. Such
-    // cases may be false positivies.
+    // We only add the current annotation as a broken ending if the current
+    // BFS has seen the beginning ID. If we were to add unconditionally, we
+    // might add endings which aren't actually reachable by the corresponding.
+    // Such cases may be false positivies.
     BrokenADEs->emplace(ID, VerAddrDepEnd(I, ID, getFullPath(I),
                                           getFullPath(I, true), ParsedDepHalfID,
                                           ParsedPathToViaFiles, ParsedFullDep));
@@ -2051,7 +2052,8 @@ void VerCtx::handleDepAnnotations(Instruction *I, MDNode *MDAnnotation) {
       // If we are able to verify one pair in
       // {ORIGINAL_ID} \cup REMAPPED_IDS.at(ORIGINAL_ID) x {ORIGINAL_ID}
       // We consider ORIGINAL_ID verified; there only exists one dependency in
-      // unoptimised IR, hence we only look for one dependency in optimised IR.
+      // unoptimised IR, hence we only look for one dependency in optimised
+      // IR.
       if (ParsedDepHalfTypeStr.find("address dep") != std::string::npos) {
         bool ParsedFullDep = std::stoi(AnnotData[4]);
 
@@ -2222,7 +2224,12 @@ PreservedAnalyses LKMMVerifier::run(Module &M, ModuleAnalysisManager &AM) {
 
 void LKMMVerifier::printBrokenDeps() {
   auto checkDepPair = [this](auto &P, auto &E) {
-    auto &ID = P.first;
+    auto ID = P.first;
+
+    // Exclude duplicate IDs by normalising them.
+    // This means we only print one representative of each equivalence class.
+    if (auto Pos = ID.find("-#"))
+      ID = ID.substr(0, Pos);
 
     auto &VDB = P.second;
 

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -301,8 +301,8 @@ public:
   /// \param I2 the instruction where the address dependency ends.
   /// \param FDep set to true if this is a full address
   ///  dependency.
-  void addAdrDep(std::string PathTo2, std::string PathToViaFiles2,
-                 Instruction *I2, bool FDep) const;
+  void addAddrDep(std::string PathTo2, std::string PathToViaFiles2,
+                  Instruction *I2, bool FDep) const;
 
   /// Resets the DepChainMap to a new state and potentially alteres the
   /// possibility of this PotAddrDepBeg being the beginning of a full
@@ -1249,8 +1249,8 @@ bool PotAddrDepBeg::belongsToSomeNotAllDepChains(BasicBlock *BB,
   return !belongsToAllDepChains(BB, VCmp) && belongsToDepChain(BB, VCmp);
 }
 
-void PotAddrDepBeg::addAdrDep(std::string PathTo2, std::string PathToViaFiles2,
-                              Instruction *I2, bool FDep) const {
+void PotAddrDepBeg::addAddrDep(std::string PathTo2, std::string PathToViaFiles2,
+                               Instruction *I2, bool FDep) const {
   auto ID = getID() + PathTo2;
 
   std::string begin_annotation = "LKMMDep: address dep begin," + ID + "," +
@@ -1731,9 +1731,9 @@ void BFSCtx::handleLoadStoreInst(Instruction &I) {
     if (I.isVolatile())
       if (isa<AnnotCtx>(this)) {
         if (ADB.belongsToAllDepChains(BB, VEnd) && ADB.canBeFullDependency())
-          ADB.addAdrDep(getFullPath(&I), getFullPath(&I, true), &I, true);
+          ADB.addAddrDep(getFullPath(&I), getFullPath(&I, true), &I, true);
         else if (ADB.belongsToSomeNotAllDepChains(BB, VEnd))
-          ADB.addAdrDep(getFullPath(&I), getFullPath(&I, true), &I, false);
+          ADB.addAddrDep(getFullPath(&I), getFullPath(&I, true), &I, false);
       }
 
     ADB.tryAddValueToDepChains(&I, I.getOperand(0), VAdd);

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 # source https://nixos.wiki/wiki/LLVM
-with import <nixpkgs> {};
+with import <nixpkgs> { };
 (mkShell.override {
   stdenv = llvmPackages_14.stdenv;
 }) {
@@ -11,10 +11,10 @@ with import <nixpkgs> {};
     clang-tools
     ninja
     graphviz
-    python39
-    python39Packages.html5lib
-    python39Packages.pyyaml
-    python39Packages.pygments
+    python310
+    python310Packages.html5lib
+    python310Packages.pyyaml
+    python310Packages.pygments
   ];
 
   disableHardening = true;


### PR DESCRIPTION
* command line arg for printing broken moduels
* Update broken dep output, e.g. add reason why dep was broken
* Don't use pathto anymore
* Python build script