### PR TITLE
Print source-level dependency chains

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
   ]);
 in
 pkgs.llvmPackages_latest.stdenv.mkDerivation {
-  name = "llvm-debug";
+  name = "llvm-debug-env";
   nativeBuildInputs = [
     pkgs.bashInteractive
     pkgs.ccache


### PR DESCRIPTION
* Fix handling (to a degree) of 'empty' functions, e.g. functions with external linkage or intrinsics. Analysis is probably overly cautios right now.
* Add ability to print source-level and IR-level dependency chains for broken deps. Source-level is default.