### PR TITLE
DepChecker: add DCUnion output when debugging

### DIFF
--- a/doitlk-llvm-build.py
+++ b/doitlk-llvm-build.py
@@ -11,8 +11,8 @@ CMAKE_CONFIG_FLAGS = [
     "-DLLVM_DEFAULT_TARGET_TRIPLE=\"aarch64-unknown-linux-gnu\"",
     "-DCMAKE_BUILD_TYPE=\"DEBUG\"", "-DLLVM_ENABLE_ASSERTIONS=\"ON\"",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS=\"ON\"", "-DLLVM_CCACHE_BUILD=\"ON\"",
-    "-DLLVM_ENABLE_LLD=\"ON\"",
-    "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"]
+    "-DLLVM_ENABLE_LLD=\"ON\"", "-DCMAKE_C_COMPILER=clang",
+    "-DCMAKE_CXX_COMPILER=clang++", "-DLLVM_ENABLE_ZLIB=\"ON\""]
 
 
 def configure_llvm():

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1088,7 +1088,7 @@ bool PotAddrDepBeg::tryAddValueToDepChains(Instruction *I, Value *VCmp,
   if (isa<ConstantData>(VAdd))
     return false;
 
-  auto Ret = false;
+  auto Ret(false);
 
   auto &DCP = DCM.at(I->getParent());
 
@@ -1099,20 +1099,12 @@ bool PotAddrDepBeg::tryAddValueToDepChains(Instruction *I, Value *VCmp,
   if (DCInter.find(VCmp) != DCInter.end()) {
     DCInter.insert(VAdd);
     Ret = true;
-  } else if (isa<StoreInst>(I)) {
-    auto *PotRedefOp = I->getOperand(1);
-    if (DCInter.find(PotRedefOp) != DCInter.end())
-      DCInter.erase(PotRedefOp);
   }
 
   // Add to DCUnion and account for redefinition
   if (DCUnion.find(VCmp) != DCUnion.end()) {
     DCUnion.insert(VAdd);
     Ret = true;
-  } else if (isa<StoreInst>(I)) {
-    auto *PotRedefOp = I->getOperand(1);
-    if (DCUnion.find(PotRedefOp) != DCUnion.end())
-      DCUnion.erase(PotRedefOp);
   }
 
   return Ret;

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -424,9 +424,14 @@ public:
     return VDH->getKind() == DK_AddrBeg;
   }
 
-  void printDepChainAt(BasicBlock *BB) {
+  void printDepChainAt(BasicBlock *BB) const {
     errs() << "printing DCInter\n";
     for (auto &V : DCM.at(BB).first) {
+      V->print(errs());
+      errs() << "\n";
+    }
+    errs() << "printing DCUnion\n";
+    for (auto &V : DCM.at(BB).second) {
       V->print(errs());
       errs() << "\n";
     }

--- a/shell.nix
+++ b/shell.nix
@@ -21,11 +21,14 @@ pkgs.llvmPackages_latest.stdenv.mkDerivation {
     myPython
     pkgs.llvmPackages_latest.lld
     pkgs.llvmPackages_latest.lldb
+    pkgs.pkg-config
   ];
+  buildInputs = [ pkgs.zlib ];
   hardeningDisable = [ "all" ];
   shellHook = ''
     export PYTHONPATH='lldb -P'
   '';
   PATH_TO_CLANG = "${pkgs.llvmPackages_latest.stdenv.cc}/bin/clang++";
-
+  # FIXME why is this not included?
+  NIX_LDFLAGS = "-rpath ${pkgs.zlib}/lib";
 }


### PR DESCRIPTION
* Make full-to-partial checks conditional on cmdline arg and only check for completely broken deps per default
* Fix handling of deps through "empty" functions
* WIP: addr dep chain redefinitions
* print dep chains for broken deps (IR values and source locations
* Use SetVector as underlying DepChain type