### PR TITLE
DynDepChecker x86 PoC

### DIFF
--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -21,7 +21,6 @@
 #include "llvm/Transforms/Utils/LKMMDependenceAnalysis.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/CFG.h"

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1369,12 +1369,7 @@ private:
 
   // TODO:When can dependencies be delegated?
   bool canBeDelegatedToDynAnalaysis(string const &ID, Instruction *IEnd) {
-    if (ID ==
-            "\n__stm_source_link_drop::1071:9\n__stm_source_link_drop::1085:2->"
-            "pm_runtime_mark_last_busy()\npm_runtime_mark_last_busy::233:"
-            "2" ||
-        ID == "\nproj_bdo_rr_addr_dep_begin_simple::41:7\nproj_"
-              "bdo_rr_addr_dep_begin_simple::45:7")
+    if (ID.find("proj_bdo_rr_addr_dep_begin_simple::47:7") != string::npos)
       return true;
     return false;
   }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1847,9 +1847,7 @@ void BFSCtx::handleCall(CallBase &CallB) {
     } else if (auto *RADB = dyn_cast<ReturnedADB>(IRetAD.get())) {
       auto &Lvl = RADB->Lvl;
       if (Lvl != DCLevel::NORET) {
-        if (RADB->DiscoveredInInterproc ||
-            (ADBs.find(ID) == ADBs.end() &&
-             InheritedADBs.find(ID) != InheritedADBs.end())) {
+        if (ADBs.find(ID) == ADBs.end()) {
           ADBs.emplace(ID, std::move(RADB->ADB));
           ADBs.at(ID).resetDCM(BB);
         }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1371,8 +1371,11 @@ private:
   // TODO:When can dependencies be delegated?
   bool canBeDelegatedToDynAnalaysis(string const &ID, Instruction *IEnd) {
     if (ID ==
-        "\n__stm_source_link_drop::1071:9\n__stm_source_link_drop::1085:2->"
-        "pm_runtime_mark_last_busy()\npm_runtime_mark_last_busy::233:2")
+            "\n__stm_source_link_drop::1071:9\n__stm_source_link_drop::1085:2->"
+            "pm_runtime_mark_last_busy()\npm_runtime_mark_last_busy::233:"
+            "2" ||
+        ID == "\nproj_bdo_rr_addr_dep_begin_simple::41:7\nproj_"
+              "bdo_rr_addr_dep_begin_simple::45:7")
       return true;
     return false;
   }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -2114,7 +2114,7 @@ void BFSCtx::visitReturnInst(ReturnInst &RetI) {
     else if (RetAtPTE)
       RADB->Lvl = DCLevel::PTE;
     else if (!ADBDiscoverdInThisF)
-      return;
+      continue;
 
     ADBsToBeReturned.push_back(std::move(RADB));
   }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -2250,7 +2250,6 @@ bool VerCtx::wasADBPreserved(string const &ID, Instruction *IEnd,
 
     if (BADE) {
       if (canBeDelegatedToDynAnalaysis(ID, IEnd)) {
-        errs() << "Adding PC section\n";
         auto *IBeg = BrokenADBs->at(ID).getInst();
 
         auto *LLVMCtx = &IEnd->getFunction()->getContext();

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1301,13 +1301,16 @@ public:
 
   void addToOutsideIDs(string ID) { OutsideIDs.insert(ID); }
 
-  void addBrokenEnding(VerAddrDepBeg VADB, VerAddrDepEnd VADE, DepChain DC,
-                       VerDepHalf::BrokenByType BrokenBy) {
+  VerAddrDepEnd *addBrokenEnding(VerAddrDepBeg VADB, VerAddrDepEnd VADE,
+                                 DepChain DC,
+                                 VerDepHalf::BrokenByType BrokenBy) {
     VADB.setDCP(DC);
 
     VADE.setBrokenBy(BrokenBy);
 
-    BrokenADEs->emplace(VADB.getID(), std::move(VADE));
+    auto R = BrokenADEs->emplace(VADB.getID(), std::move(VADE));
+
+    return R.second ? &R.first->second : nullptr;
   }
 
   static bool classof(const BFSCtx *C) { return C->getKind() == CK_Ver; }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1369,7 +1369,7 @@ private:
 
   // TODO:When can dependencies be delegated?
   bool canBeDelegatedToDynAnalaysis(string const &ID, Instruction *IEnd) {
-    if (ID.find("proj_bdo_rr_addr_dep_begin_simple::47:7") != string::npos)
+    if (ID.find("proj_bdo_rr_addr_dep_begin_simple") != string::npos)
       return true;
     return false;
   }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -2554,7 +2554,7 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
     llvm_unreachable("Invalid beginning type when printing broken dependency.");
 
   errs() << "//===--------------------------Broken "
-            "Dependency---------------------------===//\n";
+            "Dependency--------------------------===//\n";
 
   errs() << DepKindStr << " with ID: " << ID << "\n\n";
 
@@ -2622,7 +2622,7 @@ void LKMMVerifier::printBrokenDep(VerDepHalf &Beg, VerDepHalf &End,
 #undef DEBUG_TYPE
 
   errs() << "//"
-            "===-----------------------------------------------------------"
+            "===----------------------------------------------------------"
             "----"
             "-------===//\n\n";
 }

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -507,8 +507,8 @@ protected:
              string PathToViaFiles, string ParsedDepHalfID,
              string ParsedPathToViaFiles, DepKind Kind)
       : DepHalf(I, DepHalfID, PathToViaFiles, Kind), ParsedID(ParsedID),
-        ParsedDepHalfID(ParsedDepHalfID), ParsedPathToViaFiles{
-                                              ParsedPathToViaFiles} {}
+        ParsedDepHalfID(ParsedDepHalfID),
+        ParsedPathToViaFiles{ParsedPathToViaFiles} {}
 
 private:
   // Shows how this dependency got broken

--- a/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
+++ b/llvm/lib/Transforms/Utils/LKMMDependenceAnalysis.cpp
@@ -1469,18 +1469,18 @@ void PotAddrDepBeg::addAddrDep(string ID2, string PathToViaFiles2,
                                Instruction *I2) const {
   auto DepID = getInstLocString(I) + PathFrom + ID2;
 
-  auto BeginAnnotation = ADBStr.str() + ",\n" + DepID + ",\n" + getID() + ",\n";
-  auto EndAnnotation = ADEStr.str() + ",\n" + DepID + ",\n" + ID2 + ",\n";
+  auto BegAnnotStr = ADBStr.str() + ",\n" + DepID + ",\n" + getID() + ",\n";
+  auto EndAnnotStr = ADEStr.str() + ",\n" + DepID + ",\n" + ID2 + ",\n";
 
   // We only annotate if we haven't annotated this exact dependency before.
-  if (hasAnnotation(I, BeginAnnotation) && hasAnnotation(I2, EndAnnotation))
+  if (hasAnnotation(I, BegAnnotStr) && hasAnnotation(I2, EndAnnotStr))
     return;
 
-  BeginAnnotation += getPathToViaFiles() + ";";
-  EndAnnotation += PathToViaFiles2 + ",\n" + ";";
+  BegAnnotStr += getPathToViaFiles() + ";";
+  EndAnnotStr += PathToViaFiles2 + ",\n" + ";";
 
-  I->addAnnotationMetadata(BeginAnnotation);
-  I2->addAnnotationMetadata(EndAnnotation);
+  I->addAnnotationMetadata(BegAnnotStr);
+  I2->addAnnotationMetadata(EndAnnotStr);
 }
 
 bool PotAddrDepBeg::depChainsShareLink(

--- a/proj_bdo_llvm_build.py
+++ b/proj_bdo_llvm_build.py
@@ -5,7 +5,7 @@ import subprocess
 
 CMAKE_CONFIG_FLAGS = [
     "-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lldb;lld'",
-    "-DLLVM_TARGETS_TO_BUILD='AArch64;ARM'",
+    "-DLLVM_TARGETS_TO_BUILD='AArch64;ARM;X86'",
     "-DLLVM_TARGET_ARCH='AArch64'",
     "-DLLVM_DEFAULT_TARGET_TRIPLE='aarch64-unknown-linux-gnu'",
     "-DCMAKE_BUILD_TYPE='RelWithDebInfo'", "-DLLVM_ENABLE_ASSERTIONS='ON'",

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ pkgs.llvmPackages_latest.stdenv.mkDerivation {
   hardeningDisable = [ "all" ];
   shellHook = ''
     export PYTHONPATH='lldb -P'
+    export LD_LIBRARY_FLAGS="${pkgs.llvmPackages_latest.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_FLAGS"
   '';
   PATH_TO_CLANG = "${pkgs.llvmPackages_latest.stdenv.cc}/bin/clang++";
   # FIXME why is this not included?


### PR DESCRIPTION
Commits required to make the DynDepChecker x86 PoC work.

- Enable x86.
- add PC sections for simple test case.